### PR TITLE
Refine hover feedback and homepage year sampling

### DIFF
--- a/src/components/NumberOnesList.astro
+++ b/src/components/NumberOnesList.astro
@@ -86,6 +86,8 @@ const { heading, description, items } = Astro.props as Props;
     font-weight: 400;
     font-size: 1.1rem;
     color: var(--color-text-muted, rgba(0, 0, 0, 0.6));
+    display: inline-block;
+    white-space: nowrap;
   }
 
   .number-one-list__notes {

--- a/src/components/OverallRankingList.astro
+++ b/src/components/OverallRankingList.astro
@@ -12,6 +12,7 @@ interface Props {
 }
 
 const { heading, description, items } = Astro.props as Props;
+const medalIcons = ["🥇", "🥈", "🥉"];
 ---
 
 <section class="article__table" aria-labelledby={heading.replace(/\s+/g, "-").toLowerCase()}>
@@ -19,15 +20,24 @@ const { heading, description, items } = Astro.props as Props;
   {description ? <p class="section__lead">{description}</p> : null}
   <ol class="overall-ranking-list">
     {
-      items.map((entry) => (
-        <li class="overall-ranking-list__item">
-          <span class="overall-ranking-list__position">#{entry.position}</span>
-          <div class="overall-ranking-list__track">
-            <span class="overall-ranking-list__title">{entry.title}</span>
-            <span class="overall-ranking-list__artist">{entry.artist}</span>
-          </div>
-        </li>
-      ))
+      items.map((entry) => {
+        const medal = medalIcons[entry.position - 1];
+        return (
+          <li class="overall-ranking-list__item">
+            <span
+              class={`overall-ranking-list__position ${
+                medal ? "overall-ranking-list__position--medal" : ""
+              }`}
+            >
+              {medal ?? `#${entry.position}`}
+            </span>
+            <div class="overall-ranking-list__track">
+              <span class="overall-ranking-list__title">{entry.title}</span>
+              <span class="overall-ranking-list__artist">{entry.artist}</span>
+            </div>
+          </li>
+        );
+      })
     }
   </ol>
 </section>
@@ -57,6 +67,15 @@ const { heading, description, items } = Astro.props as Props;
     font-family: var(--font-heading, inherit);
     font-weight: 600;
     color: var(--color-accent, #8a2be2);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 2.75rem;
+    font-size: 1.05rem;
+  }
+
+  .overall-ranking-list__position--medal {
+    font-size: 1.35rem;
   }
 
   .overall-ranking-list__track {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,7 +1,7 @@
 ---
 import SiteLayout from "../layouts/SiteLayout.astro";
 // import ResponsiveImage from "../components/ResponsiveImage.astro";
-import { getYearGroups } from "../lib/content-utils";
+import { getYearGroups, type YearEntry } from "../lib/content-utils";
 import { getCollection } from "astro:content";
 
 // const heroImage = {
@@ -14,11 +14,41 @@ import { getCollection } from "astro:content";
 
 const [yearGroups, metaEntries] = await Promise.all([getYearGroups(), getCollection("meta")]);
 
-const flatten = <T,>(groups: Record<PropertyKey, T[]>) => Object.values(groups).flat();
-const sortByRanking = <T extends { data: { ranking: number } }>(entries: T[]) =>
-  [...entries].sort((a, b) => a.data.ranking - b.data.ranking);
+const createSeededRandom = (seed: number) => {
+  let state = seed + 0x6d2b79f5;
+  return () => {
+    state = Math.imul(state ^ (state >>> 15), state | 1);
+    state ^= state + Math.imul(state ^ (state >>> 7), state | 61);
+    return ((state ^ (state >>> 14)) >>> 0) / 4294967296;
+  };
+};
 
-const yearHighlights = sortByRanking(flatten(yearGroups)).slice(0, 3);
+const selectRandomYears = (groups: Record<number, YearEntry[]>, count: number, seed: number) => {
+  const orderedYears = Object.keys(groups)
+    .map((year) => Number(year))
+    .sort((a, b) => a - b);
+
+  const pool = orderedYears
+    .map((year) => (groups[year] ?? [])[0])
+    .filter((entry): entry is YearEntry => Boolean(entry));
+
+  if (pool.length <= count) {
+    return pool;
+  }
+
+  const random = createSeededRandom(seed);
+  const available = [...pool];
+  const selection: YearEntry[] = [];
+
+  while (selection.length < count && available.length) {
+    const index = Math.floor(random() * available.length);
+    selection.push(available.splice(index, 1)[0]);
+  }
+
+  return selection;
+};
+
+const yearHighlights = selectRandomYears(yearGroups, 4, 20240529);
 
 const sortedYears = Object.keys(yearGroups)
   .map((year) => Number(year))

--- a/src/pages/years/[slug].astro
+++ b/src/pages/years/[slug].astro
@@ -138,9 +138,15 @@ const pageDescription =
             </div>
             <div class="article-pagination__item article-pagination__item--random">
               {randomYear ? (
-                <a class="article-pagination__button" href={toHref("years", randomYear.slug)}>
-                  Surprise me
-                </a>
+                <form
+                  class="article-pagination__form"
+                  action={toHref("years", randomYear.slug)}
+                  method="get"
+                >
+                  <button class="article-pagination__button" type="submit">
+                    Surprise me
+                  </button>
+                </form>
               ) : null}
             </div>
             <div class="article-pagination__item article-pagination__item--next">

--- a/src/styles/critical.css
+++ b/src/styles/critical.css
@@ -186,7 +186,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
-  padding: 1rem 0.75rem 1rem 1rem;
+  padding: 1rem;
   border: 1px solid var(--color-rule);
   border-radius: calc(var(--radius-base) - 4px);
   background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
@@ -236,6 +236,15 @@ body {
   margin: 0 0 0.35rem;
 }
 
+.site-nav__year-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 0.35rem 0.5rem;
+}
+
 .site-nav__year-item {
   margin: 0;
 }
@@ -248,17 +257,21 @@ body {
 
 .site-nav__year-link {
   display: block;
-  padding: 0.35rem 0.25rem;
+  padding: 0.45rem 0.6rem;
   font-size: var(--scale--1);
   font-weight: 600;
   color: inherit;
   text-decoration: none;
   text-align: start;
-  transition: color var(--transition-speed) ease;
+  border-radius: 999px;
+  transition:
+    background-color var(--transition-speed) ease,
+    color var(--transition-speed) ease;
 }
 
 .site-nav__year-link:hover,
 .site-nav__year-link:focus-visible {
+  background: rgba(154, 52, 18, 0.08);
   text-decoration: underline;
   text-decoration-thickness: 2px;
   text-underline-offset: 0.15em;
@@ -368,12 +381,14 @@ a:focus-visible {
   text-decoration: none;
   font-weight: 600;
   box-shadow: 0 0.9rem 1.5rem rgba(154, 52, 18, 0.25);
-  transition: transform var(--transition-speed) ease;
+  transition:
+    background-color var(--transition-speed) ease,
+    color var(--transition-speed) ease;
 }
 
 .hero__action:hover,
 .hero__action:focus-visible {
-  transform: translateY(-2px);
+  background: #b54719;
 }
 
 .hero__action--secondary {
@@ -578,7 +593,7 @@ a:focus-visible {
   transition:
     border-color var(--transition-speed) ease,
     color var(--transition-speed) ease,
-    transform var(--transition-speed) ease;
+    background-color var(--transition-speed) ease;
 }
 
 .article-pagination__link {
@@ -591,11 +606,20 @@ a:focus-visible {
 .article-pagination__button:focus-visible {
   border-color: rgba(154, 52, 18, 0.35);
   color: var(--color-accent);
-  transform: translateY(-2px);
+  background: rgba(154, 52, 18, 0.08);
+}
+
+.article-pagination__form {
+  flex: 1;
+  display: flex;
 }
 
 .article-pagination__button {
   justify-content: center;
+  cursor: pointer;
+  font: inherit;
+  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
+  appearance: none;
 }
 
 .article-pagination__meta {

--- a/src/styles/noncritical.css
+++ b/src/styles/noncritical.css
@@ -13,41 +13,45 @@ body {
 
 .page-frame {
   transition:
-    box-shadow 220ms ease,
-    transform 220ms ease;
+    background 220ms ease,
+    border-color 220ms ease;
 }
 
 .page-frame:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 2.25rem 3.5rem rgba(16, 24, 40, 0.14);
+  background: linear-gradient(180deg, var(--color-surface) 0%, rgba(154, 52, 18, 0.12) 100%);
+  border-color: rgba(154, 52, 18, 0.28);
 }
 
 .site-nav {
-  transition: box-shadow 220ms ease;
+  transition:
+    background 220ms ease,
+    border-color 220ms ease;
 }
 
 .site-nav:hover {
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.75),
-    0 0.6rem 1.5rem rgba(16, 24, 40, 0.08);
+  background: linear-gradient(180deg, var(--color-surface) 0%, rgba(154, 52, 18, 0.16) 100%);
+  border-color: rgba(154, 52, 18, 0.32);
 }
 
 .record-card {
   transition:
-    transform 200ms ease,
-    box-shadow 200ms ease;
+    background 200ms ease,
+    border-color 200ms ease;
 }
 
 .record-card:hover,
 .record-card:focus-within {
-  transform: translateY(-2px);
-  box-shadow: 0 1.25rem 2.5rem rgba(16, 24, 40, 0.12);
+  background: linear-gradient(180deg, #ffffff 0%, rgba(154, 52, 18, 0.12) 100%);
+  border-color: rgba(154, 52, 18, 0.3);
 }
 
 .sidebar-panel {
-  transition: box-shadow 200ms ease;
+  transition:
+    background 200ms ease,
+    border-color 200ms ease;
 }
 
 .sidebar-panel:hover {
-  box-shadow: 0 1.1rem 2.2rem rgba(16, 24, 40, 0.15);
+  background: linear-gradient(180deg, #ffffff 0%, rgba(154, 52, 18, 0.1) 100%);
+  border-color: rgba(154, 52, 18, 0.28);
 }


### PR DESCRIPTION
## Summary
- replace transform-based hover states with color and background transitions for key calls to action and compress the year navigation layout
- adjust noncritical hover styling, random year pagination, and the Number Ones list so interactions remain accessible and compact
- update the homepage highlight picker to use four seeded random years and show medals for the top three in the overall rankings

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e43094345483259c3b75a049ac9131