### PR TITLE
Implement dark mode theme and tighten archive interactions

### DIFF
--- a/src/components/NumberOnesList.astro
+++ b/src/components/NumberOnesList.astro
@@ -14,13 +14,13 @@ interface Props {
 const { heading, description, items } = Astro.props as Props;
 ---
 
-<section class="article__table" aria-labelledby={heading}>
+<section class="article__table number-one-list__section" aria-labelledby={heading}>
   <u><h2 class="section__title" id={heading}>{heading}</h2></u>
   {description ? <p class="section__lead">{description}</p> : null}
   <ol class="number-one-list">
     {
       items.map((entry) => (
-        <ul class="number-one-list__item">
+        <li class="number-one-list__item">
           <div class="number-one-list__track">
             <span class="number-one-list__title">
               "{entry.title}"<span class="number-one-list__artist"> by {entry.artist}</span>
@@ -33,15 +33,17 @@ const { heading, description, items } = Astro.props as Props;
               ))}
             </ul>
           ) : null}
-        </ul>
+        </li>
       ))
     }
   </ol>
 </section>
 
 <style>
-  .section {
-    padding: 20px;
+  .number-one-list__section {
+    margin-top: clamp(2rem, 4vw, 3rem);
+    padding-top: clamp(1.5rem, 2vw, 2.25rem);
+    border-top: 1px solid var(--color-rule-strong, rgba(255, 255, 255, 0.16));
   }
 
   .number-one-list {
@@ -50,10 +52,11 @@ const { heading, description, items } = Astro.props as Props;
     padding: 0;
     margin: 0;
     list-style: none;
+    border-top: 1px solid transparent;
   }
 
   .number-one-list__item {
-    border-bottom: 1px solid var(--color-border, rgba(0, 0, 0, 0.08));
+    border-bottom: 1px solid var(--color-rule-soft, rgba(255, 255, 255, 0.12));
     padding-bottom: 1.25rem;
   }
 
@@ -79,13 +82,13 @@ const { heading, description, items } = Astro.props as Props;
   .number-one-list__title {
     font-weight: 600;
     font-size: 1.2rem;
-    color: var(--color-text, #000);
+    color: var(--color-ink, #fff);
   }
 
   .number-one-list__artist {
     font-weight: 400;
     font-size: 1.1rem;
-    color: var(--color-text-muted, rgba(0, 0, 0, 0.6));
+    color: var(--color-muted, rgba(255, 255, 255, 0.72));
     display: inline-block;
     white-space: nowrap;
   }
@@ -96,7 +99,7 @@ const { heading, description, items } = Astro.props as Props;
     padding: 0 0 0 1.25rem;
     display: grid;
     gap: 0.6rem;
-    color: var(--color-text-muted, rgba(0, 0, 0, 0.75));
+    color: var(--color-muted, rgba(255, 255, 255, 0.72));
   }
 
   @media (min-width: 48rem) {

--- a/src/lib/formatting.ts
+++ b/src/lib/formatting.ts
@@ -1,0 +1,18 @@
+const DEFAULT_EXCERPT_LIMIT = 240;
+
+export function clampExcerpt(
+  value: string | undefined | null,
+  limit = DEFAULT_EXCERPT_LIMIT
+): string {
+  if (!value) {
+    return '';
+  }
+
+  const normalized = value.trim();
+  if (normalized.length <= limit) {
+    return normalized;
+  }
+
+  const truncated = normalized.slice(0, limit - 1).trimEnd();
+  return `${truncated}…`;
+}

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,7 +2,6 @@
 import SiteLayout from "../layouts/SiteLayout.astro";
 import ResponsiveImage from "../components/ResponsiveImage.astro";
 import { getCollection } from "astro:content";
-import { getYearGroups } from "../lib/content-utils";
 
 const [aboutEntry] = await getCollection("meta", ({ slug }) => slug === "about-the-archive");
 const entry = aboutEntry ?? (await getCollection("meta"))[0];
@@ -13,14 +12,7 @@ if (!entry) {
 
 const { Content } = await entry.render();
 const tags = entry.data.tags ?? [];
-
-const yearGroups = await getYearGroups();
-const sampleYear = yearGroups[1984]?.[0];
-const sampleRanking = (await getCollection("rankings")).sort(
-  (a, b) => a.data.ranking - b.data.ranking
-)[0];
-
-const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
+const showTags = false && tags.length > 0;
 ---
 
 <SiteLayout pageTitle={entry.data.title} description={entry.data.commentary_excerpt}>
@@ -40,7 +32,7 @@ const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
       <Content />
     </div>
     {
-      tags.length ? (
+      showTags ? (
         <div class="article__tags">
           {tags.map((tag) => (
             <span class="tag-chip">{tag}</span>
@@ -49,24 +41,4 @@ const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
       ) : null
     }
   </article>
-
-  <section class="sidebar-panel" aria-labelledby="about-navigation" slot="sidebar">
-    <h2 class="sidebar-panel__title" id="about-navigation">Quick entry points</h2>
-    <ul class="sidebar-panel__list">
-      {
-        sampleYear ? (
-          <li class="sidebar-panel__item">
-            <a href={toHref("years", sampleYear.slug)}>{sampleYear.data.title}</a>
-          </li>
-        ) : null
-      }
-      {
-        sampleRanking ? (
-          <li class="sidebar-panel__item">
-            <a href={toHref("rankings", sampleRanking.slug)}>{sampleRanking.data.title}</a>
-          </li>
-        ) : null
-      }
-    </ul>
-  </section>
 </SiteLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import SiteLayout from "../layouts/SiteLayout.astro";
 // import ResponsiveImage from "../components/ResponsiveImage.astro";
 import { getYearGroups, type YearEntry } from "../lib/content-utils";
 import { getCollection } from "astro:content";
+import { clampExcerpt } from "../lib/formatting";
 
 // const heroImage = {
 //   src: "/images/meta/archive.jpg",
@@ -80,7 +81,7 @@ const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
         {
           latestYearEntry ? (
             <a class="hero__action" href={toHref("years", latestYearEntry.slug)}>
-              Explore {latestYearEntry.data.year}
+              Explore latest review
             </a>
           ) : null
         }
@@ -110,7 +111,7 @@ const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
             <h3 class="record-card__title">
               <a href={toHref("years", entry.slug)}>{entry.data.title}</a>
             </h3>
-            <p class="record-card__excerpt">{entry.data.commentary_excerpt}</p>
+            <p class="record-card__excerpt">{clampExcerpt(entry.data.commentary_excerpt)}</p>
           </article>
         ))
       }
@@ -124,7 +125,7 @@ const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
           <h2 class="sidebar-panel__title" id="sidebar-overview">
             How this archive works
           </h2>
-          <p>{aboutEntry.data.commentary_excerpt}</p>
+          <p>{clampExcerpt(aboutEntry.data.commentary_excerpt)}</p>
           <ul class="sidebar-panel__list">
             <li class="sidebar-panel__item">
               <a href="/about/">Read the full overview</a>

--- a/src/pages/rankings/[slug].astro
+++ b/src/pages/rankings/[slug].astro
@@ -53,6 +53,7 @@ const formatDate = (
 
 const toHref = (slug: string) => `/rankings/${slug}/`;
 const tags = entry.data.tags ?? [];
+const showTags = false && tags.length > 0;
 const subsetDescription =
   entry.data.subset === "top-220"
     ? "Complete Top 220 countdown derived from the research archive."
@@ -104,7 +105,7 @@ const tableHeading =
       />
     </div>
     {
-      tags.length ? (
+      showTags ? (
         <div class="article__tags">
           {tags.map((tag) => (
             <span class="tag-chip">{tag}</span>

--- a/src/pages/rankings/index.astro
+++ b/src/pages/rankings/index.astro
@@ -1,6 +1,7 @@
 ---
 import SiteLayout from "../../layouts/SiteLayout.astro";
 import { getCollection } from "astro:content";
+import { clampExcerpt } from "../../lib/formatting";
 
 const rankings = await getCollection("rankings");
 const byAscendingRank = [...rankings].sort((a, b) => a.data.ranking - b.data.ranking);
@@ -31,7 +32,7 @@ const toHref = (slug: string) => `/rankings/${slug}/`;
             <h2 class="record-card__title">
               <a href={toHref(entry.slug)}>{entry.data.title}</a>
             </h2>
-            <p class="record-card__excerpt">{entry.data.commentary_excerpt}</p>
+            <p class="record-card__excerpt">{clampExcerpt(entry.data.commentary_excerpt)}</p>
             <div class="record-card__meta">
               <span>{formatDate(entry.data.chart_week)}</span>
               <span>
@@ -60,7 +61,7 @@ const toHref = (slug: string) => `/rankings/${slug}/`;
             <h3 class="record-card__title">
               <a href={toHref(entry.slug)}>{entry.data.title}</a>
             </h3>
-            <p class="record-card__excerpt">{entry.data.commentary_excerpt}</p>
+            <p class="record-card__excerpt">{clampExcerpt(entry.data.commentary_excerpt)}</p>
             <div class="record-card__meta">
               <span>{formatDate(entry.data.chart_week)}</span>
               <span>
@@ -92,7 +93,7 @@ const toHref = (slug: string) => `/rankings/${slug}/`;
               <h3 class="record-card__title">
                 <a href={toHref(entry.slug)}>{entry.data.title}</a>
               </h3>
-              <p class="record-card__excerpt">{entry.data.commentary_excerpt}</p>
+              <p class="record-card__excerpt">{clampExcerpt(entry.data.commentary_excerpt)}</p>
               <div class="record-card__meta">
                 <span>{formatDate(entry.data.chart_week)}</span>
                 <span>

--- a/src/pages/years/[slug].astro
+++ b/src/pages/years/[slug].astro
@@ -70,6 +70,7 @@ const siblingYears = allYearEntries
 
 const toHref = (segment: string, slug: string) => `/${segment}/${slug}/`;
 const tags = entry.data.tags ?? [];
+const showTags = false && tags.length > 0;
 const summaryParagraphs = entry.data.yearSummary
   ? entry.data.yearSummary
       .split(/\n{2,}/)
@@ -97,9 +98,7 @@ const pageDescription =
       <Content />
       {
         numberOnes.length ? (
-          <>
-            <NumberOnesList heading="WEEKLY NUMBER ONES" items={numberOnes} />
-          </>
+          <NumberOnesList heading="WEEKLY NUMBER ONES" items={numberOnes} />
         ) : null
       }
       {
@@ -111,7 +110,7 @@ const pageDescription =
       }
     </div>
     {
-      tags.length ? (
+      showTags ? (
         <div class="article__tags">
           {tags.map((tag) => (
             <span class="tag-chip">{tag}</span>

--- a/src/pages/years/index.astro
+++ b/src/pages/years/index.astro
@@ -1,12 +1,13 @@
 ---
 import SiteLayout from "../../layouts/SiteLayout.astro";
 import { getYearGroups, type YearEntry } from "../../lib/content-utils";
+import { clampExcerpt } from "../../lib/formatting";
 
 const yearGroups = await getYearGroups();
 
 const sortedYears = Object.keys(yearGroups)
   .map((year) => Number(year))
-  .sort((a, b) => b - a);
+  .sort((a, b) => a - b);
 
 const yearEntries: YearEntry[] = sortedYears
   .map((year) => (yearGroups[year] ?? [])[0])
@@ -30,12 +31,10 @@ const toHref = (slug: string) => `/years/${slug}/`;
     <div class="record-grid">
       {
         yearEntries.map((entry) => (
-          <article class="record-card">
-            <h2 class="record-card__title">
-              <a href={toHref(entry.slug)}>{entry.data.title}</a>
-            </h2>
-            <p class="record-card__excerpt">{entry.data.commentary_excerpt}</p>
-          </article>
+          <a class="record-card record-card--link" href={toHref(entry.slug)}>
+            <h2 class="record-card__title">{entry.data.title}</h2>
+            <p class="record-card__excerpt">{clampExcerpt(entry.data.commentary_excerpt)}</p>
+          </a>
         ))
       }
     </div>

--- a/src/styles/critical.css
+++ b/src/styles/critical.css
@@ -15,7 +15,7 @@
 }
 
 :root {
-  color-scheme: light;
+  color-scheme: dark;
   font-family:
     'Inter',
     'Segoe UI',
@@ -26,17 +26,19 @@
   font-size: clamp(1rem, 0.18vw + 0.98rem, 1.08rem);
   line-height: 1.6;
   text-rendering: optimizeLegibility;
-  background-color: #f7f4ef;
-  color: #1b1f2b;
+  background-color: #120c08;
+  color: #f6eee3;
   --font-serif: 'Cormorant Garamond', 'Iowan Old Style', 'Palatino', 'Times New Roman', serif;
-  --color-paper: #f7f4ef;
-  --color-ink: #1b1f2b;
-  --color-muted: #4b5563;
-  --color-accent: #9a3412;
-  --color-rule: #d9cdbd;
-  --color-surface: #fcfbf8;
-  --color-surface-alt: #f1ede5;
-  --shadow-soft: 0 1.5rem 3rem rgba(16, 24, 40, 0.08);
+  --color-paper: #120c08;
+  --color-ink: #f6eee3;
+  --color-muted: rgba(238, 215, 192, 0.72);
+  --color-accent: #d39765;
+  --color-rule: rgba(231, 201, 175, 0.32);
+  --color-rule-soft: rgba(231, 201, 175, 0.18);
+  --color-rule-strong: rgba(231, 201, 175, 0.42);
+  --color-surface: #1c130e;
+  --color-surface-alt: #241810;
+  --shadow-soft: 0 1.5rem 3rem rgba(0, 0, 0, 0.55);
   --radius-base: 18px;
   --scale--1: clamp(0.875rem, 0.14vw + 0.84rem, 0.94rem);
   --scale-0: clamp(1rem, 0.18vw + 0.97rem, 1.08rem);
@@ -100,7 +102,7 @@ body {
   content: '';
   position: absolute;
   inset: clamp(0.75rem, 1.5vw, 1.5rem);
-  border: 1px solid rgba(154, 52, 18, 0.08);
+  border: 1px solid rgba(211, 151, 101, 0.14);
   border-radius: calc(var(--radius-base) - clamp(0.75rem, 1.5vw, 1.5rem));
   pointer-events: none;
 }
@@ -108,7 +110,7 @@ body {
 .page-frame::after {
   inset: clamp(1.5rem, 3vw, 2.5rem);
   border-style: dashed;
-  opacity: 0.35;
+  opacity: 0.25;
 }
 
 .site-header {
@@ -143,7 +145,7 @@ body {
 }
 
 .page-layout:focus {
-  outline: 3px solid rgba(154, 52, 18, 0.45);
+  outline: 3px solid rgba(211, 151, 101, 0.45);
   outline-offset: 6px;
 }
 
@@ -185,12 +187,12 @@ body {
 .site-nav {
   display: flex;
   flex-direction: column;
-  gap: 1.25rem;
-  padding: 1rem;
+  gap: 1rem;
+  padding: 0.85rem;
   border: 1px solid var(--color-rule);
   border-radius: calc(var(--radius-base) - 4px);
-  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  background: linear-gradient(180deg, rgba(32, 22, 17, 0.85) 0%, rgba(18, 12, 8, 0.65) 100%);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .site-nav__intro {
@@ -207,24 +209,26 @@ body {
   font-weight: 600;
   text-decoration: none;
   color: var(--color-ink);
-  padding: 0.35rem 0.65rem;
+  padding: 0.45rem 0.75rem;
   border-radius: 999px;
   border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.06);
   transition:
     background var(--transition-speed) ease,
-    color var(--transition-speed) ease;
+    color var(--transition-speed) ease,
+    border-color var(--transition-speed) ease;
 }
 
 .site-nav__home:hover,
 .site-nav__home:focus-visible {
-  border-color: rgba(154, 52, 18, 0.35);
-  background: rgba(154, 52, 18, 0.07);
+  border-color: rgba(211, 151, 101, 0.6);
+  background: rgba(211, 151, 101, 0.2);
 }
 
 .site-nav__home[aria-current='page'] {
-  border-color: rgba(154, 52, 18, 0.5);
-  background: rgba(154, 52, 18, 0.12);
-  color: var(--color-accent);
+  border-color: rgba(211, 151, 101, 0.75);
+  background: rgba(211, 151, 101, 0.28);
+  color: var(--color-ink);
 }
 
 .site-nav__heading {
@@ -239,10 +243,11 @@ body {
 .site-nav__year-list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0.15rem 0;
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.35rem 0.5rem;
+  gap: 0.25rem 0.4rem;
+  justify-items: center;
 }
 
 .site-nav__year-item {
@@ -251,34 +256,30 @@ body {
 
 .site-nav__year-item.is-current .site-nav__year-link {
   font-weight: 700;
-  color: var(--color-accent, #8a2be2);
-  text-decoration: underline;
+  color: var(--color-ink);
 }
 
 .site-nav__year-link {
-  display: block;
-  padding: 0.45rem 0.6rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.5rem;
+  min-height: 2.2rem;
   font-size: var(--scale--1);
   font-weight: 600;
   color: inherit;
   text-decoration: none;
-  text-align: start;
+  text-align: center;
   border-radius: 999px;
-  transition:
-    background-color var(--transition-speed) ease,
-    color var(--transition-speed) ease;
-}
-
-.site-nav__year-link:hover,
-.site-nav__year-link:focus-visible {
-  background: rgba(154, 52, 18, 0.08);
-  text-decoration: underline;
-  text-decoration-thickness: 2px;
-  text-underline-offset: 0.15em;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid transparent;
+  width: 100%;
 }
 
 .site-nav__year-link[aria-current='page'] {
-  color: var(--color-accent);
+  color: var(--color-ink);
+  border-color: rgba(211, 151, 101, 0.6);
+  background: rgba(211, 151, 101, 0.2);
 }
 
 main {
@@ -317,10 +318,12 @@ p {
 
 a {
   color: var(--color-accent);
+  text-decoration: underline;
 }
 
-a:hover,
 a:focus-visible {
+  outline: 2px solid rgba(211, 151, 101, 0.6);
+  outline-offset: 2px;
   text-decoration: none;
 }
 
@@ -375,12 +378,12 @@ a:focus-visible {
   align-items: center;
   gap: 0.4rem;
   background: var(--color-accent);
-  color: #fff;
+  color: #1a0f08;
   padding: 0.6rem 1rem;
   border-radius: 999px;
   text-decoration: none;
   font-weight: 600;
-  box-shadow: 0 0.9rem 1.5rem rgba(154, 52, 18, 0.25);
+  box-shadow: 0 0.9rem 1.5rem rgba(0, 0, 0, 0.35);
   transition:
     background-color var(--transition-speed) ease,
     color var(--transition-speed) ease;
@@ -388,19 +391,19 @@ a:focus-visible {
 
 .hero__action:hover,
 .hero__action:focus-visible {
-  background: #b54719;
+  background: #dda876;
 }
 
 .hero__action--secondary {
   background: transparent;
   color: var(--color-accent);
-  border: 1px solid rgba(154, 52, 18, 0.45);
+  border: 1px solid rgba(211, 151, 101, 0.6);
   box-shadow: none;
 }
 
 .hero__action--secondary:hover,
 .hero__action--secondary:focus-visible {
-  background: rgba(154, 52, 18, 0.12);
+  background: rgba(211, 151, 101, 0.18);
   color: var(--color-accent);
 }
 
@@ -411,13 +414,29 @@ a:focus-visible {
 }
 
 .record-card {
-  border: 1px solid rgba(27, 31, 43, 0.12);
+  border: 1px solid var(--color-rule);
   border-radius: 16px;
-  background: #fff;
+  background: linear-gradient(180deg, rgba(40, 26, 18, 0.92) 0%, rgba(20, 13, 9, 0.88) 100%);
   padding: 1rem 1.25rem;
   display: grid;
   gap: 0.6rem;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.35);
+}
+
+.record-card--link {
+  text-decoration: none;
+  color: inherit;
+  transition:
+    border-color var(--transition-speed) ease,
+    background-color var(--transition-speed) ease,
+    box-shadow var(--transition-speed) ease;
+}
+
+.record-card--link:hover,
+.record-card--link:focus-visible {
+  border-color: rgba(211, 151, 101, 0.6);
+  background: rgba(211, 151, 101, 0.15);
+  box-shadow: 0 1.25rem 2.75rem rgba(0, 0, 0, 0.45);
 }
 
 .record-card__title {
@@ -439,9 +458,9 @@ a:focus-visible {
 }
 
 .sidebar-panel {
-  border: 1px solid rgba(27, 31, 43, 0.12);
+  border: 1px solid var(--color-rule);
   border-radius: 16px;
-  background: linear-gradient(180deg, #ffffff 0%, #f7f3eb 100%);
+  background: linear-gradient(180deg, rgba(40, 27, 20, 0.92) 0%, rgba(18, 12, 8, 0.85) 100%);
   padding: 1.25rem;
   display: grid;
   gap: 0.75rem;
@@ -466,7 +485,6 @@ a:focus-visible {
   text-decoration: none;
 }
 
-.sidebar-panel__item a:hover,
 .sidebar-panel__item a:focus-visible {
   color: var(--color-accent);
 }
@@ -479,7 +497,7 @@ a:focus-visible {
 }
 
 .sidebar-panel__item.is-current {
-  background: rgba(154, 52, 18, 0.08); /* warm tint that matches your accent */
+  background: rgba(211, 151, 101, 0.15);
   border-radius: 6px;
   padding: 0.25rem 0.5rem;
 }
@@ -587,9 +605,9 @@ a:focus-visible {
   border: 1px solid var(--color-rule);
   text-decoration: none;
   font-weight: 600;
-  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
-  color: inherit;
+  background: linear-gradient(180deg, rgba(35, 23, 17, 0.95) 0%, rgba(18, 12, 8, 0.85) 100%);
+  box-shadow: 0 0.75rem 1.75rem rgba(0, 0, 0, 0.35);
+  color: var(--color-ink);
   transition:
     border-color var(--transition-speed) ease,
     color var(--transition-speed) ease,
@@ -604,9 +622,9 @@ a:focus-visible {
 .article-pagination__link:focus-visible,
 .article-pagination__button:hover,
 .article-pagination__button:focus-visible {
-  border-color: rgba(154, 52, 18, 0.35);
-  color: var(--color-accent);
-  background: rgba(154, 52, 18, 0.08);
+  border-color: rgba(211, 151, 101, 0.6);
+  color: var(--color-ink);
+  background: rgba(211, 151, 101, 0.2);
 }
 
 .article-pagination__form {
@@ -618,7 +636,7 @@ a:focus-visible {
   justify-content: center;
   cursor: pointer;
   font: inherit;
-  background: linear-gradient(180deg, var(--color-surface) 0%, var(--color-surface-alt) 100%);
+  background: linear-gradient(180deg, rgba(35, 23, 17, 0.95) 0%, rgba(18, 12, 8, 0.85) 100%);
   appearance: none;
 }
 

--- a/src/styles/noncritical.css
+++ b/src/styles/noncritical.css
@@ -1,10 +1,10 @@
 body {
   background-image:
-    linear-gradient(180deg, rgba(247, 244, 239, 0) 0%, rgba(215, 202, 184, 0.35) 100%),
+    linear-gradient(180deg, rgba(18, 12, 8, 0) 0%, rgba(38, 24, 16, 0.65) 100%),
     repeating-linear-gradient(
       90deg,
-      rgba(154, 52, 18, 0.03) 0,
-      rgba(154, 52, 18, 0.03) 1px,
+      rgba(211, 151, 101, 0.05) 0,
+      rgba(211, 151, 101, 0.05) 1px,
       transparent 1px,
       transparent 18px
     );
@@ -17,20 +17,10 @@ body {
     border-color 220ms ease;
 }
 
-.page-frame:hover {
-  background: linear-gradient(180deg, var(--color-surface) 0%, rgba(154, 52, 18, 0.12) 100%);
-  border-color: rgba(154, 52, 18, 0.28);
-}
-
 .site-nav {
   transition:
     background 220ms ease,
     border-color 220ms ease;
-}
-
-.site-nav:hover {
-  background: linear-gradient(180deg, var(--color-surface) 0%, rgba(154, 52, 18, 0.16) 100%);
-  border-color: rgba(154, 52, 18, 0.32);
 }
 
 .record-card {
@@ -39,19 +29,8 @@ body {
     border-color 200ms ease;
 }
 
-.record-card:hover,
-.record-card:focus-within {
-  background: linear-gradient(180deg, #ffffff 0%, rgba(154, 52, 18, 0.12) 100%);
-  border-color: rgba(154, 52, 18, 0.3);
-}
-
 .sidebar-panel {
   transition:
     background 200ms ease,
     border-color 200ms ease;
-}
-
-.sidebar-panel:hover {
-  background: linear-gradient(180deg, #ffffff 0%, rgba(154, 52, 18, 0.1) 100%);
-  border-color: rgba(154, 52, 18, 0.28);
 }


### PR DESCRIPTION
## Summary
- introduce a reusable clampExcerpt helper and apply it to home, rankings, and yearly listings while renaming the hero CTA to "Explore latest review"
- remove the About quick entry sidebar, hide tag chips sitewide, and make each year card fully clickable in ascending order
- refresh the palette with a brown-inspired dark theme, constrain hover styling to approved controls, center and tighten the Yearly Rankings sidebar, and add spacing plus a top border before Weekly Number Ones

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e43bd6633483258a5ff58a7ab79451